### PR TITLE
fix(ui): restore tab visibility after M3 migration

### DIFF
--- a/src/main/res/layout/activity_image_tabs.xml
+++ b/src/main/res/layout/activity_image_tabs.xml
@@ -17,14 +17,16 @@
         <com.google.android.material.appbar.AppBarLayout
             android:id="@+id/appbar"
             android:layout_width="match_parent"
-            android:layout_height="@dimen/image_tabs_header_size"
+            android:layout_height="wrap_content"
+            android:elevation="4dp"
             android:fitsSystemWindows="true"
+            android:stateListAnimator="@null"
             android:theme="@style/ThemeOverlay.MaterialComponents.Dark.ActionBar">
 
             <com.google.android.material.appbar.CollapsingToolbarLayout
                 android:id="@+id/collapsingToolbar"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
+                android:layout_height="@dimen/image_tabs_header_size"
                 android:fitsSystemWindows="true"
                 app:contentScrim="?attr/colorPrimary"
                 app:layout_scrollFlags="scroll|exitUntilCollapsed">
@@ -59,19 +61,17 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_gravity="top"
-                    android:layout_marginBottom="48dp"
                     app:layout_collapseMode="pin" />
 
-                <com.google.android.material.tabs.TabLayout
-                    android:id="@+id/tabs"
-                    style="@style/Widget.MaterialComponents.TabLayout.Colored"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="bottom"
-                    android:background="@android:color/transparent"
-                    app:tabMode="auto" />
-
             </com.google.android.material.appbar.CollapsingToolbarLayout>
+
+            <com.google.android.material.tabs.TabLayout
+                android:id="@+id/tabs"
+                style="@style/Widget.App.TabLayout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?attr/colorPrimary"
+                app:tabMode="auto" />
 
         </com.google.android.material.appbar.AppBarLayout>
 

--- a/src/main/res/layout/activity_main.xml
+++ b/src/main/res/layout/activity_main.xml
@@ -26,7 +26,7 @@
 
             <com.google.android.material.tabs.TabLayout
                 android:id="@+id/tabs"
-                style="@style/Widget.MaterialComponents.TabLayout.Colored"
+                style="@style/Widget.App.TabLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="?attr/colorPrimary"

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -85,6 +85,12 @@
         <item name="android:background">?attr/colorPrimary</item>
     </style>
 
+    <style name="Widget.App.TabLayout" parent="Widget.Material3.TabLayout">
+        <item name="tabIndicatorColor">@color/on_primary</item>
+        <item name="tabSelectedTextColor">@color/on_primary</item>
+        <item name="tabTextColor">@color/on_primary</item>
+    </style>
+
     <style name="Widget.App.Toolbar" parent="Widget.Material3.Toolbar">
         <item name="popupTheme">@style/ThemeOverlay.App</item>
         <item name="colorControlNormal">?attr/colorOnSurface</item>


### PR DESCRIPTION
Three compounding issues made tabs invisible in ImageTabsActivity:

1. Widget.MaterialComponents.TabLayout.Colored resolves tabTextColor via colorOnSurfaceVariant in M3 bridge mode — dark text on dark primary background. Fix: Widget.App.TabLayout (M3 parent) with explicit @color/on_primary for text and indicator.

2. AppBarLayout stateListAnimator sets elevation=0 when not lifted, so ViewPager2 draws on top in CoordinatorLayout, covering the dark scrim that provided tab contrast. Fix: stateListAnimator=@null
   + android:elevation="4dp" to pin draw order.

3. CollapsingToolbarLayout fitsSystemWindows adds bottom padding in M3 edge-to-edge inset handling, clipping the bottom-gravity TabLayout entirely outside the drawable area. Fix: move TabLayout out of CTL to a sibling position in AppBarLayout (no scroll flags = stays pinned). AppBarLayout height changed to wrap_content; CTL gets the explicit image_tabs_header_size.
