### PR TITLE
feat(episode): restore language flag buttons with hoster icons

### DIFF
--- a/docs/superpowers/plans/2026-07-18-episode-language-buttons.md
+++ b/docs/superpowers/plans/2026-07-18-episode-language-buttons.md
@@ -1,0 +1,697 @@
+# Episode/Chapter Language Buttons Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:subagent-driven-development (recommended) or superpowers-extended-cc:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the stacked plain-text language labels in the episode/chapter list with side-by-side outlined buttons carrying flag icons and (for anime) hoster icons.
+
+**Architecture:** Add a `@DrawableRes` flag-resource seam to `ProxerLibExtensions.kt` so Compose can use `painterResource`. Add a private `LanguageButton` composable to `EpisodeScreen.kt` and render the available languages in a wrapping `FlowRow`. Languages absent from the API are already never iterated, so "no button when unavailable" needs no explicit handling.
+
+**Tech Stack:** Kotlin 2.2.10, Jetpack Compose (BOM 2026.06.01), Material3, Coil 2.7.0 (`AsyncImage`), JUnit4, Compose UI test (`androidx.compose.ui.test.junit4.v2`).
+
+**Spec:** `docs/superpowers/specs/2026-07-18-episode-language-buttons-design.md`
+
+**Baseline:** `./gradlew testDebugUnitTest` → 365 tests, 0 failures (recorded before any change).
+
+---
+
+### Correction to the spec
+
+The spec's testing section lists a JVM test asserting `toAppDrawable(context)` still resolves after being rewritten. That call goes through `AppCompatResources.getDrawable`, which needs the Android framework and is not available in a plain JVM unit test. This plan keeps the pure `toAppDrawableRes()` mapping in the JVM suite (Task 1) and does not add a JVM test for the `Context`-taking overload. Its behaviour is unchanged — it is a one-line delegation — and it stays covered by every existing View-layer caller.
+
+---
+
+### Task 1: Flag resource helper
+
+**Goal:** Add `Language.toAppDrawableRes()` returning a `@DrawableRes Int`, and make the existing `toAppDrawable(context)` delegate to it.
+
+**Files:**
+- Modify: `src/main/kotlin/me/proxer/app/util/extension/ProxerLibExtensions.kt:135-142`
+- Create: `src/test/kotlin/me/proxer/app/util/extension/ProxerLibExtensionsTest.kt`
+
+**Acceptance Criteria:**
+- [ ] `Language.GERMAN.toAppDrawableRes()` returns `R.drawable.ic_germany`
+- [ ] `Language.ENGLISH.toAppDrawableRes()` returns `R.drawable.ic_united_states`
+- [ ] `Language.OTHER.toAppDrawableRes()` returns `R.drawable.ic_united_nations`
+- [ ] `toAppDrawable(context)` no longer contains its own `when` — it calls `toAppDrawableRes()`
+- [ ] Full JVM suite still green (365 existing + 4 new)
+
+**Verify:** `./gradlew testDebugUnitTest --tests "me.proxer.app.util.extension.ProxerLibExtensionsTest"` → `BUILD SUCCESSFUL`, 4 tests passing
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/test/kotlin/me/proxer/app/util/extension/ProxerLibExtensionsTest.kt`:
+
+```kotlin
+package me.proxer.app.util.extension
+
+import me.proxer.app.R
+import me.proxer.library.enums.Language
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class ProxerLibExtensionsTest {
+
+    @Test fun `toAppDrawableRes maps german to the germany flag`() {
+        assertEquals(R.drawable.ic_germany, Language.GERMAN.toAppDrawableRes())
+    }
+
+    @Test fun `toAppDrawableRes maps english to the united states flag`() {
+        assertEquals(R.drawable.ic_united_states, Language.ENGLISH.toAppDrawableRes())
+    }
+
+    @Test fun `toAppDrawableRes maps other to the united nations flag`() {
+        assertEquals(R.drawable.ic_united_nations, Language.OTHER.toAppDrawableRes())
+    }
+
+    @Test fun `toAppDrawableRes resolves a real resource for every language`() {
+        Language.values().forEach { language ->
+            assertNotEquals("No drawable for $language", 0, language.toAppDrawableRes())
+        }
+    }
+}
+```
+
+This test file intentionally does NOT use `KoinTestRule`. `ProxerLibExtensionsTest` must stay free of `ErrorUtils`, which binds `StorageHelper`/`PreferenceHelper` via `by lazy` once per JVM and poisons sibling tests (see CLAUDE.md).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew testDebugUnitTest --tests "me.proxer.app.util.extension.ProxerLibExtensionsTest"`
+Expected: FAIL — compilation error, `Unresolved reference: toAppDrawableRes`
+
+- [ ] **Step 3: Add the helper and delegate**
+
+In `src/main/kotlin/me/proxer/app/util/extension/ProxerLibExtensions.kt`, add this import alongside the existing `androidx.appcompat.content.res.AppCompatResources` import (imports are alphabetically sorted — `androidx.annotation.DrawableRes` sorts before `androidx.appcompat`):
+
+```kotlin
+import androidx.annotation.DrawableRes
+```
+
+Then replace the existing block at lines 135-142:
+
+```kotlin
+fun Language.toAppDrawable(context: Context) = AppCompatResources.getDrawable(
+    context,
+    when (this) {
+        Language.GERMAN -> R.drawable.ic_germany
+        Language.ENGLISH -> R.drawable.ic_united_states
+        Language.OTHER -> R.drawable.ic_united_nations
+    },
+) ?: error("Could not resolve Drawable for language: $this")
+```
+
+with:
+
+```kotlin
+@DrawableRes
+fun Language.toAppDrawableRes() = when (this) {
+    Language.GERMAN -> R.drawable.ic_germany
+    Language.ENGLISH -> R.drawable.ic_united_states
+    Language.OTHER -> R.drawable.ic_united_nations
+}
+
+fun Language.toAppDrawable(context: Context) = AppCompatResources.getDrawable(context, toAppDrawableRes())
+    ?: error("Could not resolve Drawable for language: $this")
+```
+
+Leave the `Country.toAppDrawable` function immediately below untouched — it is a different enum and out of scope.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew testDebugUnitTest --tests "me.proxer.app.util.extension.ProxerLibExtensionsTest"`
+Expected: PASS, 4 tests
+
+- [ ] **Step 5: Run the full suite to confirm nothing regressed**
+
+Run: `./gradlew testDebugUnitTest`
+Expected: `BUILD SUCCESSFUL`, 369 tests, 0 failures
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/kotlin/me/proxer/app/util/extension/ProxerLibExtensions.kt src/test/kotlin/me/proxer/app/util/extension/ProxerLibExtensionsTest.kt
+git commit -m "feat: add Language.toAppDrawableRes for Compose flag icons"
+```
+
+---
+
+### Task 2: `LanguageButton` composable and `FlowRow` wiring
+
+**Goal:** Render each available language as an outlined button with a flag icon and, for anime, its hoster icons — laid out side by side and wrapping.
+
+**Files:**
+- Modify: `src/main/kotlin/me/proxer/app/media/episode/EpisodeScreen.kt:206-239` (expanded section), plus imports
+
+**Acceptance Criteria:**
+- [ ] Expanding an episode row shows one `OutlinedButton` per available language, arranged horizontally
+- [ ] Each button shows the flag at 16dp followed by the language label
+- [ ] Anime buttons whose language has hoster images show a `VerticalDivider` then one 18dp `AsyncImage` per hoster
+- [ ] Manga/novel buttons show neither divider nor hoster icons (`hosterImages` is `null` there)
+- [ ] Buttons wrap to a second line rather than overflowing when four languages are present
+- [ ] Tapping a button navigates exactly as before (same `AnimeActivity`/`MangaActivity` arguments)
+- [ ] `./gradlew detekt` reports no new findings
+
+**Verify:** `./gradlew compileDebugKotlin detekt` → `BUILD SUCCESSFUL`
+
+**Steps:**
+
+- [ ] **Step 1: Add the required imports**
+
+In `src/main/kotlin/me/proxer/app/media/episode/EpisodeScreen.kt`, add to the existing import block (keep alphabetical ordering — ktlint enforces it):
+
+```kotlin
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import coil.compose.AsyncImage
+import me.proxer.app.util.extension.toAppDrawableRes
+import me.proxer.library.util.ProxerUrls
+```
+
+Keep the existing `androidx.compose.foundation.clickable` import — the bookmark dialog still uses it.
+
+- [ ] **Step 2: Add the `LanguageButton` composable**
+
+Append to `EpisodeScreen.kt`, after the `EpisodeItem` function and before `EpisodeContentPreview`:
+
+```kotlin
+@Composable
+private fun LanguageButton(language: MediaLanguage, hosterImages: List<String>?, onClick: () -> Unit) {
+    val context = LocalContext.current
+
+    OutlinedButton(
+        onClick = onClick,
+        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp),
+    ) {
+        Image(
+            painter = painterResource(language.toGeneralLanguage().toAppDrawableRes()),
+            contentDescription = null,
+            modifier = Modifier.size(16.dp),
+        )
+
+        Spacer(modifier = Modifier.width(6.dp))
+
+        Text(
+            text = language.toAppString(context),
+            style = MaterialTheme.typography.labelLarge,
+        )
+
+        if (!hosterImages.isNullOrEmpty()) {
+            VerticalDivider(
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .height(16.dp),
+            )
+
+            hosterImages.forEach { hosterImage ->
+                AsyncImage(
+                    model = ProxerUrls.hosterImage(hosterImage).toString(),
+                    contentDescription = null,
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier
+                        .padding(end = 4.dp)
+                        .size(18.dp),
+                )
+            }
+        }
+    }
+}
+```
+
+`contentDescription = null` on both images is deliberate: the label `Text` sits inside the same button and already carries the meaning, so a description would produce a duplicate announcement. This matches every non-TV screen in the codebase.
+
+- [ ] **Step 3: Extract the navigation logic**
+
+Append to `EpisodeScreen.kt`, after `LanguageButton`:
+
+```kotlin
+private fun navigateToEpisode(
+    activity: Activity,
+    episode: EpisodeRow,
+    language: MediaLanguage,
+    mediaId: String,
+    mediaName: String?,
+) = when (episode.category) {
+    Category.ANIME -> AnimeActivity.navigateTo(
+        activity,
+        mediaId,
+        episode.number,
+        language.toAnimeLanguage(),
+        mediaName,
+        episode.episodeAmount,
+    )
+
+    Category.MANGA, Category.NOVEL -> MangaActivity.navigateTo(
+        activity,
+        mediaId,
+        episode.number,
+        language.toGeneralLanguage(),
+        episode.title,
+        mediaName,
+        episode.episodeAmount,
+    )
+}
+```
+
+- [ ] **Step 4: Replace the expanded section**
+
+In `EpisodeItem`, replace the whole `if (expanded) { ... }` block at lines 206-239:
+
+```kotlin
+        if (expanded) {
+            episode.languageHosterList.forEach { (language, _) ->
+                Text(
+                    text = language.toAppString(context),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            activity ?: return@clickable
+                            when (episode.category) {
+                                Category.ANIME -> AnimeActivity.navigateTo(
+                                    activity,
+                                    mediaId,
+                                    episode.number,
+                                    language.toAnimeLanguage(),
+                                    mediaName,
+                                    episode.episodeAmount,
+                                )
+
+                                Category.MANGA, Category.NOVEL -> MangaActivity.navigateTo(
+                                    activity,
+                                    mediaId,
+                                    episode.number,
+                                    language.toGeneralLanguage(),
+                                    episode.title,
+                                    mediaName,
+                                    episode.episodeAmount,
+                                )
+                            }
+                        }
+                        .padding(top = 4.dp, start = 8.dp),
+                )
+            }
+        }
+```
+
+with:
+
+```kotlin
+        if (expanded) {
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.padding(top = 8.dp),
+            ) {
+                episode.languageHosterList.forEach { (language, hosterImages) ->
+                    LanguageButton(
+                        language = language,
+                        hosterImages = hosterImages,
+                        onClick = {
+                            if (activity != null) {
+                                navigateToEpisode(activity, episode, language, mediaId, mediaName)
+                            }
+                        },
+                    )
+                }
+            }
+        }
+```
+
+Note the destructuring now binds `hosterImages` instead of discarding it with `_` — that is the piece the Compose migration dropped.
+
+After this edit, the `context` val at the top of `EpisodeItem` may become unused (the label lookup moved into `LanguageButton`). Check whether `context` is still referenced inside `EpisodeItem`; if it is not, delete the `val context = LocalContext.current` line to avoid a compiler warning. `val activity = context as? Activity` still needs it, so most likely both stay — verify rather than assume.
+
+- [ ] **Step 5: Compile and lint**
+
+Run: `./gradlew compileDebugKotlin detekt`
+Expected: `BUILD SUCCESSFUL`, no new detekt findings
+
+- [ ] **Step 6: Run the unit suite**
+
+Run: `./gradlew testDebugUnitTest`
+Expected: `BUILD SUCCESSFUL`, 369 tests, 0 failures
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/main/kotlin/me/proxer/app/media/episode/EpisodeScreen.kt
+git commit -m "feat(episode): show languages as flag buttons with hoster icons"
+```
+
+---
+
+### Task 3: Flags in the bookmark language dialog
+
+**Goal:** Show the same flag icon beside each language in the bookmark language picker, so the two lists look consistent.
+
+**Files:**
+- Modify: `src/main/kotlin/me/proxer/app/media/episode/EpisodeScreen.kt:117-135` (the `AlertDialog` text block)
+
+**Acceptance Criteria:**
+- [ ] Long-pressing an episode opens the bookmark dialog with a flag before each language label
+- [ ] Flags render at 20dp (larger than the 16dp in buttons, to match the dialog's `bodyLarge` text)
+- [ ] No hoster icons appear in the dialog
+- [ ] Tapping a row still calls `onBookmark` with the same arguments and dismisses the dialog
+
+**Verify:** `./gradlew compileDebugKotlin detekt` → `BUILD SUCCESSFUL`
+
+**Steps:**
+
+- [ ] **Step 1: Replace the dialog's language list**
+
+In `EpisodeContent`, inside the `AlertDialog`'s `text = { Column { ... } }` block, replace:
+
+```kotlin
+                    episodeToBookmark.languageHosterList.forEach { (language, _) ->
+                        Text(
+                            text = language.toAppString(context),
+                            style = MaterialTheme.typography.bodyLarge,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    onBookmark(
+                                        episodeToBookmark.number,
+                                        language,
+                                        episodeToBookmark.category,
+                                    )
+                                    bookmarkEpisode = null
+                                }
+                                .padding(vertical = 12.dp),
+                        )
+                    }
+```
+
+with:
+
+```kotlin
+                    episodeToBookmark.languageHosterList.forEach { (language, _) ->
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    onBookmark(
+                                        episodeToBookmark.number,
+                                        language,
+                                        episodeToBookmark.category,
+                                    )
+                                    bookmarkEpisode = null
+                                }
+                                .padding(vertical = 12.dp),
+                        ) {
+                            Image(
+                                painter = painterResource(language.toGeneralLanguage().toAppDrawableRes()),
+                                contentDescription = null,
+                                modifier = Modifier.size(20.dp),
+                            )
+
+                            Spacer(modifier = Modifier.width(12.dp))
+
+                            Text(
+                                text = language.toAppString(context),
+                                style = MaterialTheme.typography.bodyLarge,
+                            )
+                        }
+                    }
+```
+
+The `clickable` modifier deliberately stays on the `Row` rather than moving to the `Text`, so the whole row including the flag remains one tap target.
+
+All imports this needs (`Image`, `painterResource`, `Spacer`, `width`, `size`, `toAppDrawableRes`) were already added in Task 2. `Row` and `Alignment` are already imported in this file.
+
+- [ ] **Step 2: Compile and lint**
+
+Run: `./gradlew compileDebugKotlin detekt`
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/kotlin/me/proxer/app/media/episode/EpisodeScreen.kt
+git commit -m "feat(episode): show flags in the bookmark language dialog"
+```
+
+---
+
+### Task 4: Collapse the duplicate flag mapping in `MediaListScreen`
+
+**Goal:** Point the inline flag mapping in `MediaListScreen` at the new shared helper so the drawable choice lives in one place.
+
+**Files:**
+- Modify: `src/main/kotlin/me/proxer/app/media/list/MediaListScreen.kt:425-439`
+
+**Acceptance Criteria:**
+- [ ] `MediaListScreen` no longer references `R.drawable.ic_germany` or `R.drawable.ic_united_states` directly
+- [ ] The rendered output is unchanged — same two conditional 16dp flags, same `contentDescription` strings
+- [ ] `./gradlew compileDebugKotlin detekt` passes
+
+**Verify:** `./gradlew compileDebugKotlin detekt` → `BUILD SUCCESSFUL`, and `grep -c 'R.drawable.ic_germany' src/main/kotlin/me/proxer/app/media/list/MediaListScreen.kt` → `0`
+
+**Steps:**
+
+- [ ] **Step 1: Add the import**
+
+Add to `src/main/kotlin/me/proxer/app/media/list/MediaListScreen.kt` (alphabetical position among the other `me.proxer.app.util.extension.*` imports):
+
+```kotlin
+import me.proxer.app.util.extension.toAppDrawableRes
+```
+
+- [ ] **Step 2: Replace the inline mapping**
+
+Replace lines 425-439:
+
+```kotlin
+                val languages = entry.languages.map { it.toGeneralLanguage() }.distinct()
+                if (languages.contains(Language.GERMAN)) {
+                    Image(
+                        painter = painterResource(R.drawable.ic_germany),
+                        contentDescription = stringResource(R.string.language_german),
+                        modifier = Modifier.size(16.dp),
+                    )
+                }
+                if (languages.contains(Language.ENGLISH)) {
+                    Image(
+                        painter = painterResource(R.drawable.ic_united_states),
+                        contentDescription = stringResource(R.string.language_english),
+                        modifier = Modifier.size(16.dp),
+                    )
+                }
+```
+
+with:
+
+```kotlin
+                val languages = entry.languages.map { it.toGeneralLanguage() }.distinct()
+                if (languages.contains(Language.GERMAN)) {
+                    Image(
+                        painter = painterResource(Language.GERMAN.toAppDrawableRes()),
+                        contentDescription = stringResource(R.string.language_german),
+                        modifier = Modifier.size(16.dp),
+                    )
+                }
+                if (languages.contains(Language.ENGLISH)) {
+                    Image(
+                        painter = painterResource(Language.ENGLISH.toAppDrawableRes()),
+                        contentDescription = stringResource(R.string.language_english),
+                        modifier = Modifier.size(16.dp),
+                    )
+                }
+```
+
+The two explicit `if` branches are kept on purpose. Rewriting this as a loop over `languages` would also render a flag for `Language.OTHER`, which is a behaviour change this task does not want. Only the drawable lookup moves to the shared helper.
+
+- [ ] **Step 3: Verify no direct drawable references remain**
+
+Run: `grep -n 'R.drawable.ic_germany\|R.drawable.ic_united_states' src/main/kotlin/me/proxer/app/media/list/MediaListScreen.kt`
+Expected: no output
+
+- [ ] **Step 4: Compile and lint**
+
+Run: `./gradlew compileDebugKotlin detekt`
+Expected: `BUILD SUCCESSFUL`
+
+If `R` or `painterResource` became unused after this edit, remove the stale import. `R` is almost certainly still used (`R.string.language_german` remains) — check rather than assume.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/kotlin/me/proxer/app/media/list/MediaListScreen.kt
+git commit -m "refactor(media): reuse toAppDrawableRes for media list flags"
+```
+
+---
+
+### Task 5: Compose UI test for button rendering
+
+**Goal:** Assert that exactly the available languages get a button, and absent ones get none.
+
+**Files:**
+- Modify: `src/main/kotlin/me/proxer/app/media/episode/EpisodeScreen.kt` (widen `EpisodeContent` from `private` to `internal`)
+- Create: `src/androidTest/kotlin/me/proxer/app/media/episode/EpisodeScreenTest.kt`
+
+**Acceptance Criteria:**
+- [ ] A row built with `GERMAN_SUB` + `ENGLISH_SUB` shows both labels after expanding
+- [ ] A row built with only `GERMAN_SUB` shows that label and NOT the English one
+- [ ] Language labels are absent before the row is expanded
+- [ ] Test class runs green on an API 31+ emulator
+
+**Verify:** `./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=me.proxer.app.media.episode.EpisodeScreenTest` → `BUILD SUCCESSFUL`, 3 tests passing
+
+⚠️ **This verification requires a running API 31+ emulator or device.** Per CLAUDE.md, mockk-android's agent instruments `Object.toString()` process-wide and Espresso reflects over an API 31+ class, so API 30 and below crash the whole instrumentation process. If no such device is attached, report the task as implemented-but-unverified rather than claiming a pass — do NOT substitute a JVM run as evidence.
+
+**Steps:**
+
+- [ ] **Step 1: Make `EpisodeContent` reachable from the test**
+
+In `src/main/kotlin/me/proxer/app/media/episode/EpisodeScreen.kt`, change the declaration at line 83:
+
+```kotlin
+private fun EpisodeContent(
+```
+
+to:
+
+```kotlin
+internal fun EpisodeContent(
+```
+
+Leave the `@Composable` annotation and every parameter untouched. This mirrors `TvEpisodeScreenContent`, which is likewise exposed so `TvEpisodeScreenTest` can drive it directly.
+
+- [ ] **Step 2: Write the test**
+
+Create `src/androidTest/kotlin/me/proxer/app/media/episode/EpisodeScreenTest.kt`:
+
+```kotlin
+package me.proxer.app.media.episode
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.MutableLiveData
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import me.proxer.app.R
+import me.proxer.app.ui.compose.ProxerTheme
+import me.proxer.app.util.extension.toEpisodeAppString
+import me.proxer.library.entity.anime.AnimeEpisode
+import me.proxer.library.enums.Category
+import me.proxer.library.enums.MediaLanguage
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class EpisodeScreenTest {
+
+    @get:Rule val composeTestRule = createComposeRule()
+
+    private val context get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private fun episodeRow(vararg languages: MediaLanguage) = EpisodeRow(
+        category = Category.ANIME,
+        userProgress = null,
+        episodeAmount = 12,
+        episodes = languages.map { language ->
+            AnimeEpisode(
+                number = 1,
+                language = language,
+                hosters = emptySet(),
+                hosterImages = emptyList(),
+            )
+        },
+    )
+
+    private fun setContent(row: EpisodeRow) {
+        composeTestRule.setContent {
+            ProxerTheme {
+                EpisodeContent(
+                    data = listOf(row),
+                    error = null,
+                    isLoading = false,
+                    mediaId = "1",
+                    mediaName = "Test Media",
+                    bookmarkResult = MutableLiveData(null),
+                    bookmarkError = MutableLiveData(null),
+                    onRetry = {},
+                    onBookmark = { _, _, _ -> },
+                )
+            }
+        }
+    }
+
+    private val episodeTitle get() = Category.ANIME.toEpisodeAppString(context, 1)
+    private val germanSub get() = context.getString(R.string.language_german_sub)
+    private val englishSub get() = context.getString(R.string.language_english_sub)
+
+    @Test fun `language_buttons_are_hidden_until_the_row_is_expanded`() {
+        setContent(episodeRow(MediaLanguage.GERMAN_SUB, MediaLanguage.ENGLISH_SUB))
+
+        composeTestRule.onNodeWithText(germanSub).assertDoesNotExist()
+        composeTestRule.onNodeWithText(englishSub).assertDoesNotExist()
+    }
+
+    @Test fun `expanding_shows_one_button_per_available_language`() {
+        setContent(episodeRow(MediaLanguage.GERMAN_SUB, MediaLanguage.ENGLISH_SUB))
+
+        composeTestRule.onNodeWithText(episodeTitle).performClick()
+
+        composeTestRule.onNodeWithText(germanSub).assertIsDisplayed()
+        composeTestRule.onNodeWithText(englishSub).assertIsDisplayed()
+    }
+
+    @Test fun `an_unavailable_language_gets_no_button`() {
+        setContent(episodeRow(MediaLanguage.GERMAN_SUB))
+
+        composeTestRule.onNodeWithText(episodeTitle).performClick()
+
+        composeTestRule.onNodeWithText(germanSub).assertIsDisplayed()
+        composeTestRule.onNodeWithText(englishSub).assertDoesNotExist()
+    }
+}
+```
+
+`assertDoesNotExist()` is an extension on `SemanticsNodeInteraction` and needs no separate import beyond the ones listed.
+
+- [ ] **Step 3: Check for an attached device**
+
+Run: `adb devices`
+Expected: at least one `device` entry whose API level is 31 or higher (`adb shell getprop ro.build.version.sdk`).
+
+If none is attached, stop here, commit the test, and report it as unverified.
+
+- [ ] **Step 4: Run the instrumented test**
+
+Run: `./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=me.proxer.app.media.episode.EpisodeScreenTest`
+Expected: `BUILD SUCCESSFUL`, 3 tests, 0 failures
+
+Note `connectedDebugAndroidTest` does NOT accept `--tests` — the `-P` form above is the only filter that works here.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/kotlin/me/proxer/app/media/episode/EpisodeScreen.kt src/androidTest/kotlin/me/proxer/app/media/episode/EpisodeScreenTest.kt
+git commit -m "test(episode): cover language button rendering"
+```
+
+---
+
+## Final verification
+
+- [ ] `./gradlew testDebugUnitTest` → 369 tests, 0 failures
+- [ ] `./gradlew detekt` → `BUILD SUCCESSFUL`
+- [ ] `./gradlew assembleDebug` → `BUILD SUCCESSFUL`
+- [ ] Manual check on a device: open any anime, Episodes tab, expand a row — flags and hoster icons appear side by side; open any manga, expand a chapter — flags appear, no hoster icons, no divider

--- a/docs/superpowers/plans/2026-07-18-episode-language-buttons.md.tasks.json
+++ b/docs/superpowers/plans/2026-07-18-episode-language-buttons.md.tasks.json
@@ -1,0 +1,48 @@
+{
+  "planPath": "docs/superpowers/plans/2026-07-18-episode-language-buttons.md",
+  "specPath": "docs/superpowers/specs/2026-07-18-episode-language-buttons-design.md",
+  "branch": "worktree-episode-language-buttons",
+  "baseline": "./gradlew testDebugUnitTest - 365 tests, 0 failures",
+  "tasks": [
+    {
+      "id": 0,
+      "nativeTaskId": "10",
+      "subject": "Task 1: Flag resource helper",
+      "status": "pending",
+      "description": "**Goal:** Add `Language.toAppDrawableRes()` returning a `@DrawableRes Int`, and make the existing `toAppDrawable(context)` delegate to it.\n\n**Files:**\n- Modify: `src/main/kotlin/me/proxer/app/util/extension/ProxerLibExtensions.kt:135-142`\n- Create: `src/test/kotlin/me/proxer/app/util/extension/ProxerLibExtensionsTest.kt`\n\n**Acceptance Criteria:**\n- GERMAN maps to ic_germany; ENGLISH to ic_united_states; OTHER to ic_united_nations\n- toAppDrawable(context) delegates instead of holding its own `when`\n- Full JVM suite green at 369 tests\n\n**Verify:** `./gradlew testDebugUnitTest --tests \"me.proxer.app.util.extension.ProxerLibExtensionsTest\"`\n\n**Steps:** See plan document Task 1 for full code. TDD: failing test first, then add `@DrawableRes fun Language.toAppDrawableRes()` plus one-line delegating overload. Do NOT use KoinTestRule in the new test file.\n\n```json:metadata\n{\"files\": [\"src/main/kotlin/me/proxer/app/util/extension/ProxerLibExtensions.kt\", \"src/test/kotlin/me/proxer/app/util/extension/ProxerLibExtensionsTest.kt\"], \"verifyCommand\": \"./gradlew testDebugUnitTest --tests \\\"me.proxer.app.util.extension.ProxerLibExtensionsTest\\\"\", \"acceptanceCriteria\": [\"GERMAN maps to ic_germany\", \"ENGLISH maps to ic_united_states\", \"OTHER maps to ic_united_nations\", \"toAppDrawable delegates to toAppDrawableRes\", \"full JVM suite green at 369 tests\"]}\n```"
+    },
+    {
+      "id": 1,
+      "nativeTaskId": "11",
+      "subject": "Task 2: LanguageButton composable and FlowRow wiring",
+      "status": "pending",
+      "blockedBy": [0],
+      "description": "**Goal:** Render each available language as an outlined button with a flag icon and, for anime, its hoster icons - laid out side by side and wrapping.\n\n**Files:**\n- Modify: `src/main/kotlin/me/proxer/app/media/episode/EpisodeScreen.kt:206-239` plus imports\n\n**Acceptance Criteria:**\n- One OutlinedButton per available language, arranged horizontally\n- Flag at 16dp then label in each button\n- VerticalDivider plus 18dp AsyncImage per hoster, only when hosterImages is non-empty\n- Manga/novel buttons show neither divider nor hoster icons\n- Buttons wrap at four languages\n- Navigation arguments unchanged\n- detekt reports no new findings\n\n**Verify:** `./gradlew compileDebugKotlin detekt`\n\n**Steps:** See plan document Task 2 for full code. Add imports alphabetically; add private LanguageButton composable; extract navigateToEpisode; replace the expanded block with FlowRow destructuring `hosterImages` instead of `_`.\n\n```json:metadata\n{\"files\": [\"src/main/kotlin/me/proxer/app/media/episode/EpisodeScreen.kt\"], \"verifyCommand\": \"./gradlew compileDebugKotlin detekt\", \"acceptanceCriteria\": [\"one OutlinedButton per available language, laid out horizontally\", \"flag at 16dp then label in each button\", \"divider plus 18dp hoster icons only when hosterImages is non-empty\", \"manga rows show no divider or hoster icons\", \"buttons wrap at four languages\", \"navigation arguments unchanged\", \"detekt clean\"]}\n```"
+    },
+    {
+      "id": 2,
+      "nativeTaskId": "12",
+      "subject": "Task 3: Flags in the bookmark language dialog",
+      "status": "pending",
+      "blockedBy": [1],
+      "description": "**Goal:** Show the same flag icon beside each language in the bookmark language picker.\n\n**Files:**\n- Modify: `src/main/kotlin/me/proxer/app/media/episode/EpisodeScreen.kt:117-135`\n\n**Acceptance Criteria:**\n- Flag before each language label in the bookmark dialog\n- Flags at 20dp to match bodyLarge text\n- No hoster icons in the dialog\n- onBookmark still called with the same arguments; dialog dismisses\n\n**Verify:** `./gradlew compileDebugKotlin detekt`\n\n**Steps:** See plan document Task 3 for full code. Wrap each entry in a Row carrying the existing clickable modifier, containing a 20dp flag Image, 12dp Spacer, and the existing Text.\n\n```json:metadata\n{\"files\": [\"src/main/kotlin/me/proxer/app/media/episode/EpisodeScreen.kt\"], \"verifyCommand\": \"./gradlew compileDebugKotlin detekt\", \"acceptanceCriteria\": [\"flag before each language label in the bookmark dialog\", \"flags at 20dp\", \"no hoster icons in the dialog\", \"onBookmark still called with the same arguments and dialog dismisses\"]}\n```"
+    },
+    {
+      "id": 3,
+      "nativeTaskId": "13",
+      "subject": "Task 4: Collapse duplicate flag mapping in MediaListScreen",
+      "status": "pending",
+      "blockedBy": [0],
+      "description": "**Goal:** Point the inline flag mapping in MediaListScreen at the new shared helper.\n\n**Files:**\n- Modify: `src/main/kotlin/me/proxer/app/media/list/MediaListScreen.kt:425-439`\n\n**Acceptance Criteria:**\n- No direct R.drawable.ic_germany or ic_united_states references remain\n- Rendered output unchanged: two conditional 16dp flags, same contentDescription strings\n- compileDebugKotlin and detekt pass\n\n**Verify:** `./gradlew compileDebugKotlin detekt` and `grep -c 'R.drawable.ic_germany' src/main/kotlin/me/proxer/app/media/list/MediaListScreen.kt` returns 0\n\n**Steps:** See plan document Task 4. KEEP the two explicit `if` branches - looping over `languages` would also render a flag for Language.OTHER, a behaviour change this task does not want.\n\n```json:metadata\n{\"files\": [\"src/main/kotlin/me/proxer/app/media/list/MediaListScreen.kt\"], \"verifyCommand\": \"./gradlew compileDebugKotlin detekt\", \"acceptanceCriteria\": [\"no direct R.drawable.ic_germany or ic_united_states references remain\", \"rendered output unchanged: two conditional 16dp flags with the same contentDescription strings\", \"compileDebugKotlin and detekt pass\"]}\n```"
+    },
+    {
+      "id": 4,
+      "nativeTaskId": "14",
+      "subject": "Task 5: Compose UI test for button rendering",
+      "status": "pending",
+      "blockedBy": [1],
+      "description": "**Goal:** Assert that exactly the available languages get a button, and absent ones get none.\n\n**Files:**\n- Modify: `src/main/kotlin/me/proxer/app/media/episode/EpisodeScreen.kt` (widen EpisodeContent to internal at line 83)\n- Create: `src/androidTest/kotlin/me/proxer/app/media/episode/EpisodeScreenTest.kt`\n\n**Acceptance Criteria:**\n- Two-language row shows both labels after expanding\n- Single-language row shows only that label\n- Labels absent before expanding\n- Green on an API 31+ emulator\n\n**Verify:** `./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=me.proxer.app.media.episode.EpisodeScreenTest`\n\nREQUIRES A RUNNING API 31+ EMULATOR OR DEVICE. On API 30 and below the whole instrumentation process crashes (mockk-android agent plus Espresso reflecting over an API 31+ class). If no such device is attached, commit the test and report it as implemented-but-unverified. Do NOT substitute a JVM run as evidence of a pass.\n\n**Steps:** See plan document Task 5 for the full test source.\n\n```json:metadata\n{\"files\": [\"src/main/kotlin/me/proxer/app/media/episode/EpisodeScreen.kt\", \"src/androidTest/kotlin/me/proxer/app/media/episode/EpisodeScreenTest.kt\"], \"verifyCommand\": \"./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=me.proxer.app.media.episode.EpisodeScreenTest\", \"acceptanceCriteria\": [\"two-language row shows both labels after expanding\", \"single-language row shows only that label\", \"labels absent before expanding\", \"green on an API 31+ emulator\"], \"requiresDevice\": \"android-api-31-plus\"}\n```"
+    }
+  ],
+  "lastUpdated": "2026-07-18"
+}

--- a/docs/superpowers/specs/2026-07-18-episode-language-buttons-design.md
+++ b/docs/superpowers/specs/2026-07-18-episode-language-buttons-design.md
@@ -1,0 +1,168 @@
+# Episode/Chapter language buttons with flag icons
+
+**Date:** 2026-07-18
+**Status:** Approved
+**Branch:** `worktree-episode-language-buttons` (worktree at `.claude/worktrees/episode-language-buttons`, based on `origin/master` @ `4ca3c67c`)
+**Baseline:** `./gradlew testDebugUnitTest` — 365 tests, 0 failures
+
+## Problem
+
+In the episode list (anime) and chapter list (manga/novel), expanding a row renders each
+available language as a full-width plain-text label stacked vertically:
+
+```kotlin
+// EpisodeScreen.kt:206-239
+if (expanded) {
+    episode.languageHosterList.forEach { (language, _) ->
+        Text(
+            text = language.toAppString(context),
+            ...
+            modifier = Modifier.fillMaxWidth().clickable { ... },
+        )
+    }
+}
+```
+
+Two regressions from the pre-Compose UI:
+
+1. **No flag icons.** The old `EpisodeAdapter` set the flag as a compound drawable on the
+   language `TextView`; the languages sat side by side in equal-weight columns.
+2. **No hoster icons.** The old `layout_episode_language.xml` had a `FlexboxLayout` showing
+   which streaming hosts served each anime language. `EpisodeRow.languageHosterList` still
+   carries this data, but `EpisodeScreen` destructures it away (`{ (language, _) -> }`) at
+   both line 118 and line 207 and never renders it.
+
+Both were lost in commit `bff49889` ("feat: migrate Media detail screen to Compose").
+
+## Scope note: it is not always two languages
+
+The originating request describes "two labels for English and German". That holds for
+manga/novel chapters, which carry `MediaLanguage.GERMAN` / `MediaLanguage.ENGLISH`. Anime
+episodes can carry up to **four**: `GERMAN_SUB`, `GERMAN_DUB`, `ENGLISH_SUB`, `ENGLISH_DUB`.
+
+A flag alone cannot distinguish GerSub from GerDub, so each button carries **flag *and*
+label**, and the layout must survive four buttons on a narrow phone.
+
+"If a language is not available the button should not be there" requires no explicit
+handling: the code iterates `languageHosterList`, which only contains languages the API
+returned. Absent languages were never rendered.
+
+## Design
+
+### 1. Shared flag resource helper
+
+`Language.toAppDrawable(context)` (`ProxerLibExtensions.kt:135`) returns a `Drawable`, which
+Compose cannot use with `painterResource`. Three Compose call sites already work around this
+by inlining their own mapping.
+
+Add the missing seam to `ProxerLibExtensions.kt`:
+
+```kotlin
+@DrawableRes
+fun Language.toAppDrawableRes() = when (this) {
+    Language.GERMAN -> R.drawable.ic_germany
+    Language.ENGLISH -> R.drawable.ic_united_states
+    Language.OTHER -> R.drawable.ic_united_nations
+}
+```
+
+Rewrite the existing `toAppDrawable(context)` to delegate to it, so the mapping has one
+source of truth. Collapse the inline duplicate at `MediaListScreen.kt:425-439` onto it.
+
+The `Country -> @DrawableRes Int` duplicates in `TranslatorGroupScreen.kt:413` and
+`IndustryScreen.kt:432` are a **different enum** and out of scope.
+
+### 2. `LanguageButton` composable
+
+New private composable in `EpisodeScreen.kt`. An `OutlinedButton` laying out, in order:
+
+- flag `Image` at 16dp, from `language.toGeneralLanguage().toAppDrawableRes()`
+- the label `Text` from `language.toAppString(context)`
+- **only when `hosterImages` is non-null and non-empty:** a `VerticalDivider`, then one
+  `AsyncImage` per hoster at 18dp
+
+Hoster images load via Coil from `ProxerUrls.hosterImage(...)` with `ContentScale.Fit`,
+matching the existing call site at `AnimeScreen.kt:606`. Coil is the established Compose
+image loader here (`io.coil-kt:coil-compose:2.7.0`); Glide has no Compose integration
+artifact in this project.
+
+Manga and novel chapters have no hosters — only `AnimeEpisode` exposes `hosterImages`
+(`EpisodeRow.kt:36`), so chapter rows render plain pills and the divider never appears.
+
+`contentDescription = null` on both image types, matching the convention across every
+non-TV screen: the adjacent label text carries the meaning, and a description would cause a
+duplicate announcement.
+
+### 3. Wiring into `EpisodeItem`
+
+`EpisodeScreen.kt:206-239` becomes:
+
+```kotlin
+if (expanded) {
+    FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        episode.languageHosterList.forEach { (language, hosterImages) ->
+            LanguageButton(
+                language = language,
+                hosterImages = hosterImages,
+                onClick = { navigateToEpisode(activity, episode, language, mediaId, mediaName) },
+            )
+        }
+    }
+}
+```
+
+`FlowRow` is already used in `BookmarkScreen.kt:396` and `MediaListScreen.kt:511`, so this
+introduces no new idiom. Buttons are content-sized and wrap to a second line when they run
+out of width — chosen over equal-width columns because four anime language variants get
+cramped on a narrow phone.
+
+The navigation `when (episode.category)` block is currently a ~20-line lambda nested inside
+a modifier. Extract it to a private `navigateToEpisode(...)` function so the layout code
+stays readable. Behaviour is unchanged.
+
+### 4. Bookmark dialog consistency
+
+The bookmark language picker (`EpisodeScreen.kt:117-135`) lists the same languages as bare
+text. Add the same flag `Image` before each label, at 20dp — slightly larger than the 16dp
+used in the buttons, to match the dialog's `bodyLarge` text. Hoster icons are **not** shown
+here: the dialog is about picking a language to bookmark, not about where to watch.
+
+## Testing
+
+**JVM** (`src/test`, runs in CI):
+- `toAppDrawableRes()` maps GERMAN → `ic_germany`, ENGLISH → `ic_united_states`,
+  OTHER → `ic_united_nations`.
+- `toAppDrawable(context)` still resolves for all three values after being rewritten to
+  delegate.
+
+**Instrumented** (`src/androidTest`, manual verification only):
+- `EpisodeScreenTest`: a two-language row renders exactly two language buttons; a
+  one-language row renders exactly one.
+
+Precedent: `TvEpisodeScreenTest.kt`. Compose UI test deps are already declared
+(`androidx.compose.ui:ui-test-junit4`). Per CLAUDE.md these require an **API 31+** emulator
+and will not run in the `testDebugUnitTest` gate, so this test is written but verified
+manually.
+
+## Error handling
+
+Unchanged. No Coil call site in this codebase sets a `placeholder` or `error` drawable, so a
+hoster logo that fails to load leaves blank space — identical to `AnimeScreen` today. Not
+worth diverging for.
+
+## Files
+
+| File | Change |
+|---|---|
+| `util/extension/ProxerLibExtensions.kt` | Add `Language.toAppDrawableRes()`; delegate `toAppDrawable()` to it |
+| `media/episode/EpisodeScreen.kt` | Add `LanguageButton` + `navigateToEpisode`; rewrite expanded section as `FlowRow`; add flags to bookmark dialog |
+| `media/list/MediaListScreen.kt` | Collapse inline flag mapping onto `toAppDrawableRes()` |
+| `src/test/kotlin/me/proxer/app/util/extension/ProxerLibExtensionsTest.kt` | **New file** (no extension tests exist today) — drawable mapping tests |
+| `src/androidTest/kotlin/me/proxer/app/media/episode/EpisodeScreenTest.kt` | **New file, new directory** (`media/` currently holds only `list/` and `MediaScreenTest.kt`) — button rendering tests |
+
+## Out of scope
+
+- `TvEpisodeScreen.kt`, which renders raw `lang.name` chips — this change targets the
+  phone/tablet UI.
+- The `Country -> Drawable` duplication in `TranslatorGroupScreen` / `IndustryScreen`.
+- Replacing `ic_united_states` with a UK flag for English (pre-existing choice, unrelated).

--- a/docs/superpowers/specs/2026-07-18-episode-language-buttons-design.md
+++ b/docs/superpowers/specs/2026-07-18-episode-language-buttons-design.md
@@ -78,8 +78,14 @@ New private composable in `EpisodeScreen.kt`. An `OutlinedButton` laying out, in
 
 - flag `Image` at 16dp, from `language.toGeneralLanguage().toAppDrawableRes()`
 - the label `Text` from `language.toAppString(context)`
-- **only when `hosterImages` is non-null and non-empty:** a `VerticalDivider`, then one
-  `AsyncImage` per hoster at 18dp
+- **only when `hosterImages` is non-null and non-empty:** a `VerticalDivider`, then a
+  horizontally scrollable `Row` holding one `AsyncImage` per hoster at 18dp
+
+The hoster `Row` carries `Modifier.weight(1f, fill = false).horizontalScroll(...)`. The button
+hugs its content, so a long label plus many hosters can exceed the `FlowRow` line width;
+`FlowRow` wraps *between* buttons but cannot wrap *within* one. The weight lets the row shrink
+rather than clip, and the scroll keeps the overflowing icons reachable. This is what the
+pre-Compose `FlexboxLayout` achieved by wrapping.
 
 Hoster images load via Coil from `ProxerUrls.hosterImage(...)` with `ContentScale.Fit`,
 matching the existing call site at `AnimeScreen.kt:606`. Coil is the established Compose
@@ -89,9 +95,18 @@ artifact in this project.
 Manga and novel chapters have no hosters — only `AnimeEpisode` exposes `hosterImages`
 (`EpisodeRow.kt:36`), so chapter rows render plain pills and the divider never appears.
 
-`contentDescription = null` on both image types, matching the convention across every
-non-TV screen: the adjacent label text carries the meaning, and a description would cause a
-duplicate announcement.
+**Accessibility.** The two image types get different treatment, for different reasons:
+
+- **Flag: `contentDescription = null`.** The language label sits inside the same button, so a
+  description would make a screen reader announce "Deutsch, GerSub". Note this is *not* the
+  blanket codebase convention — `MediaListScreen.kt:426-441` describes the identical flag
+  drawable with `stringResource(R.string.language_german)`, and correctly so: there the flag
+  stands alone with no adjacent text. The rule is "describe it when nothing else does", not
+  "always null".
+- **Hoster icons: described.** Which host serves an episode appears nowhere else as text, so
+  leaving these null would drop the information entirely for screen-reader users. `hosterImages`
+  holds image filenames rather than display names, so the description is the filename with its
+  extension stripped (`crunchyroll.jpg` → `crunchyroll`). Lowercase, but informative.
 
 ### 3. Wiring into `EpisodeItem`
 
@@ -135,9 +150,14 @@ here: the dialog is about picking a language to bookmark, not about where to wat
 - `toAppDrawable(context)` still resolves for all three values after being rewritten to
   delegate.
 
-**Instrumented** (`src/androidTest`, manual verification only):
-- `EpisodeScreenTest`: a two-language row renders exactly two language buttons; a
-  one-language row renders exactly one.
+**Instrumented** (`src/androidTest`):
+- `EpisodeScreenTest`: language buttons hidden until expanded; one button per available
+  language; an unavailable language gets none; one hoster icon per hoster image; no hoster row
+  when the list is empty; each language gets its own row; overflowing hoster icons stay
+  reachable via `performScrollTo()`; icons are described by filename minus extension.
+- Hoster assertions pass `useUnmergedTree = true` — `OutlinedButton` merges its descendants'
+  semantics, so tagged child nodes are invisible in the merged tree.
+- Verified 2026-07-18: 9/9 green on `Pixel_10_Pro_XL` (API 37) in ~18s.
 
 Precedent: `TvEpisodeScreenTest.kt`. Compose UI test deps are already declared
 (`androidx.compose.ui:ui-test-junit4`). Per CLAUDE.md these require an **API 31+** emulator

--- a/src/androidTest/kotlin/me/proxer/app/media/episode/EpisodeScreenTest.kt
+++ b/src/androidTest/kotlin/me/proxer/app/media/episode/EpisodeScreenTest.kt
@@ -1,0 +1,96 @@
+package me.proxer.app.media.episode
+
+import androidx.appcompat.view.ContextThemeWrapper
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.MutableLiveData
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import me.proxer.app.R
+import me.proxer.app.ui.compose.ProxerTheme
+import me.proxer.app.util.ErrorUtils.ErrorAction
+import me.proxer.app.util.extension.toEpisodeAppString
+import me.proxer.library.entity.info.AnimeEpisode
+import me.proxer.library.enums.Category
+import me.proxer.library.enums.MediaLanguage
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class EpisodeScreenTest {
+
+    @get:Rule val composeTestRule = createComposeRule()
+
+    private val context get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private val germanSubLabel get() = context.getString(R.string.language_german_sub)
+    private val englishSubLabel get() = context.getString(R.string.language_english_sub)
+    private val episodeTitle get() = Category.ANIME.toEpisodeAppString(context, 1)
+
+    private fun episodeRow(vararg languages: MediaLanguage) = EpisodeRow(
+        category = Category.ANIME,
+        userProgress = null,
+        episodeAmount = 12,
+        episodes = languages.map { language ->
+            AnimeEpisode(
+                number = 1,
+                language = language,
+                hosters = emptySet(),
+                hosterImages = emptyList(),
+            )
+        },
+    )
+
+    private fun setContent(row: EpisodeRow) = composeTestRule.setContent {
+        // ProxerTheme resolves colorPrimary and friends off the context theme; the bare host Activity behind
+        // createComposeRule has no app theme, so resolveColor throws unless the context is wrapped explicitly.
+        val themedContext = ContextThemeWrapper(LocalContext.current, R.style.Theme_App)
+
+        CompositionLocalProvider(LocalContext provides themedContext) {
+            ProxerTheme {
+                EpisodeContent(
+                    data = listOf(row),
+                    error = null,
+                    isLoading = false,
+                    mediaId = "1",
+                    mediaName = "Test Media",
+                    bookmarkResult = MutableLiveData<Unit?>(null),
+                    bookmarkError = MutableLiveData<ErrorAction?>(null),
+                    onRetry = {},
+                    onBookmark = { _, _, _ -> },
+                )
+            }
+        }
+    }
+
+    @Test fun `language_buttons_are_hidden_before_expanding`() {
+        setContent(episodeRow(MediaLanguage.GERMAN_SUB, MediaLanguage.ENGLISH_SUB))
+
+        composeTestRule.onNodeWithText(episodeTitle).assertIsDisplayed()
+        composeTestRule.onNodeWithText(germanSubLabel).assertDoesNotExist()
+        composeTestRule.onNodeWithText(englishSubLabel).assertDoesNotExist()
+    }
+
+    @Test fun `language_buttons_are_shown_after_expanding`() {
+        setContent(episodeRow(MediaLanguage.GERMAN_SUB, MediaLanguage.ENGLISH_SUB))
+
+        composeTestRule.onNodeWithText(episodeTitle).performClick()
+
+        composeTestRule.onNodeWithText(germanSubLabel).assertIsDisplayed()
+        composeTestRule.onNodeWithText(englishSubLabel).assertIsDisplayed()
+    }
+
+    @Test fun `only_available_languages_are_shown`() {
+        setContent(episodeRow(MediaLanguage.GERMAN_SUB))
+
+        composeTestRule.onNodeWithText(episodeTitle).performClick()
+
+        composeTestRule.onNodeWithText(germanSubLabel).assertIsDisplayed()
+        composeTestRule.onNodeWithText(englishSubLabel).assertDoesNotExist()
+    }
+}

--- a/src/androidTest/kotlin/me/proxer/app/media/episode/EpisodeScreenTest.kt
+++ b/src/androidTest/kotlin/me/proxer/app/media/episode/EpisodeScreenTest.kt
@@ -3,10 +3,14 @@ package me.proxer.app.media.episode
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.lifecycle.MutableLiveData
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -32,16 +36,19 @@ class EpisodeScreenTest {
     private val englishSubLabel get() = context.getString(R.string.language_english_sub)
     private val episodeTitle get() = Category.ANIME.toEpisodeAppString(context, 1)
 
-    private fun episodeRow(vararg languages: MediaLanguage) = EpisodeRow(
+    private fun episodeRow(vararg languages: MediaLanguage) =
+        episodeRowWithHosters(*languages.map { it to emptyList<String>() }.toTypedArray())
+
+    private fun episodeRowWithHosters(vararg entries: Pair<MediaLanguage, List<String>>) = EpisodeRow(
         category = Category.ANIME,
         userProgress = null,
         episodeAmount = 12,
-        episodes = languages.map { language ->
+        episodes = entries.map { (language, hosterImages) ->
             AnimeEpisode(
                 number = 1,
                 language = language,
                 hosters = emptySet(),
-                hosterImages = emptyList(),
+                hosterImages = hosterImages,
             )
         },
     )
@@ -92,5 +99,85 @@ class EpisodeScreenTest {
 
         composeTestRule.onNodeWithText(germanSubLabel).assertIsDisplayed()
         composeTestRule.onNodeWithText(englishSubLabel).assertDoesNotExist()
+    }
+
+    // The hoster assertions below all pass useUnmergedTree = true: OutlinedButton merges its
+    // descendants' semantics, so the tagged icon nodes are invisible in the merged tree.
+
+    @Test fun `one_hoster_icon_is_rendered_per_hoster_image`() {
+        setContent(
+            episodeRowWithHosters(
+                MediaLanguage.GERMAN_SUB to listOf("crunchyroll.jpg", "vidoza.jpg", "streamcloud.jpg"),
+            ),
+        )
+
+        composeTestRule.onNodeWithText(episodeTitle).performClick()
+
+        composeTestRule.onAllNodesWithTag(HOSTER_ICON_TEST_TAG, useUnmergedTree = true).assertCountEquals(3)
+        composeTestRule.onAllNodesWithTag(HOSTER_ROW_TEST_TAG, useUnmergedTree = true).assertCountEquals(1)
+    }
+
+    @Test fun `no_hoster_row_is_rendered_when_there_are_no_hoster_images`() {
+        setContent(episodeRow(MediaLanguage.GERMAN_SUB, MediaLanguage.ENGLISH_SUB))
+
+        composeTestRule.onNodeWithText(episodeTitle).performClick()
+
+        composeTestRule.onAllNodesWithTag(HOSTER_ROW_TEST_TAG, useUnmergedTree = true).assertCountEquals(0)
+        composeTestRule.onAllNodesWithTag(HOSTER_ICON_TEST_TAG, useUnmergedTree = true).assertCountEquals(0)
+    }
+
+    @Test fun `each_language_gets_its_own_hoster_row`() {
+        setContent(
+            episodeRowWithHosters(
+                MediaLanguage.GERMAN_SUB to listOf("crunchyroll.jpg"),
+                MediaLanguage.ENGLISH_SUB to listOf("vidoza.jpg", "streamcloud.jpg"),
+            ),
+        )
+
+        composeTestRule.onNodeWithText(episodeTitle).performClick()
+
+        composeTestRule.onAllNodesWithTag(HOSTER_ROW_TEST_TAG, useUnmergedTree = true).assertCountEquals(2)
+        composeTestRule.onAllNodesWithTag(HOSTER_ICON_TEST_TAG, useUnmergedTree = true).assertCountEquals(3)
+    }
+
+    @Test fun `a_language_without_hosters_gets_no_row_even_when_a_sibling_has_them`() {
+        setContent(
+            episodeRowWithHosters(
+                MediaLanguage.GERMAN_SUB to listOf("crunchyroll.jpg"),
+                MediaLanguage.ENGLISH_SUB to emptyList(),
+            ),
+        )
+
+        composeTestRule.onNodeWithText(episodeTitle).performClick()
+
+        composeTestRule.onAllNodesWithTag(HOSTER_ROW_TEST_TAG, useUnmergedTree = true).assertCountEquals(1)
+        composeTestRule.onAllNodesWithTag(HOSTER_ICON_TEST_TAG, useUnmergedTree = true).assertCountEquals(1)
+    }
+
+    @Test fun `hoster_icons_that_overflow_the_button_stay_reachable_by_scrolling`() {
+        val manyHosters = (1..12).map { "hoster$it.jpg" }
+
+        setContent(episodeRowWithHosters(MediaLanguage.GERMAN_SUB to manyHosters))
+
+        composeTestRule.onNodeWithText(episodeTitle).performClick()
+
+        composeTestRule.onAllNodesWithTag(HOSTER_ICON_TEST_TAG, useUnmergedTree = true).assertCountEquals(12)
+
+        // performScrollTo only succeeds inside a scrollable container, so this fails if the
+        // horizontalScroll modifier is ever dropped and the trailing icons get clipped instead.
+        composeTestRule
+            .onNodeWithContentDescription("hoster12", useUnmergedTree = true)
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Test fun `hoster_icons_are_described_by_their_name_without_the_file_extension`() {
+        setContent(episodeRowWithHosters(MediaLanguage.GERMAN_SUB to listOf("crunchyroll.jpg")))
+
+        composeTestRule.onNodeWithText(episodeTitle).performClick()
+
+        composeTestRule
+            .onNodeWithContentDescription("crunchyroll", useUnmergedTree = true)
+            .assertExists()
     }
 }

--- a/src/main/kotlin/me/proxer/app/media/episode/EpisodeScreen.kt
+++ b/src/main/kotlin/me/proxer/app/media/episode/EpisodeScreen.kt
@@ -233,6 +233,7 @@ private fun EpisodeItem(episode: EpisodeRow, mediaId: String, mediaName: String?
         if (expanded) {
             FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
                 modifier = Modifier.padding(top = 8.dp),
             ) {
                 episode.languageHosterList.forEach { (language, hosterImages) ->

--- a/src/main/kotlin/me/proxer/app/media/episode/EpisodeScreen.kt
+++ b/src/main/kotlin/me/proxer/app/media/episode/EpisodeScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -20,6 +21,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Check
@@ -46,6 +48,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -252,6 +255,9 @@ private fun EpisodeItem(episode: EpisodeRow, mediaId: String, mediaName: String?
     }
 }
 
+internal const val HOSTER_ROW_TEST_TAG = "episode_hoster_row"
+internal const val HOSTER_ICON_TEST_TAG = "episode_hoster_icon"
+
 @Composable
 private fun LanguageButton(language: MediaLanguage, hosterImages: List<String>?, onClick: () -> Unit) {
     val context = LocalContext.current
@@ -280,15 +286,27 @@ private fun LanguageButton(language: MediaLanguage, hosterImages: List<String>?,
                     .height(16.dp),
             )
 
-            hosterImages.forEach { hosterImage ->
-                AsyncImage(
-                    model = ProxerUrls.hosterImage(hosterImage).toString(),
-                    contentDescription = null,
-                    contentScale = ContentScale.Fit,
-                    modifier = Modifier
-                        .padding(end = 4.dp)
-                        .size(18.dp),
-                )
+            // The button hugs its content, so a long label plus many hosters can exceed the
+            // FlowRow line width. weight(fill = false) lets this row shrink instead of clipping
+            // the trailing icons, and horizontalScroll makes the overflow reachable.
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .weight(1f, fill = false)
+                    .horizontalScroll(rememberScrollState())
+                    .testTag(HOSTER_ROW_TEST_TAG),
+            ) {
+                hosterImages.forEach { hosterImage ->
+                    AsyncImage(
+                        model = ProxerUrls.hosterImage(hosterImage).toString(),
+                        contentDescription = hosterImage.substringBeforeLast('.'),
+                        contentScale = ContentScale.Fit,
+                        modifier = Modifier
+                            .size(18.dp)
+                            .testTag(HOSTER_ICON_TEST_TAG),
+                    )
+                }
             }
         }
     }

--- a/src/main/kotlin/me/proxer/app/media/episode/EpisodeScreen.kt
+++ b/src/main/kotlin/me/proxer/app/media/episode/EpisodeScreen.kt
@@ -2,14 +2,22 @@ package me.proxer.app.media.episode
 
 import android.app.Activity
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -20,10 +28,12 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -34,12 +44,15 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import coil.compose.AsyncImage
 import kotlinx.coroutines.launch
 import me.proxer.app.R
 import me.proxer.app.anime.AnimeActivity
@@ -49,11 +62,13 @@ import me.proxer.app.ui.compose.ObserveLiveDataEvent
 import me.proxer.app.ui.compose.ProxerTheme
 import me.proxer.app.util.ErrorUtils.ErrorAction
 import me.proxer.app.util.extension.toAnimeLanguage
+import me.proxer.app.util.extension.toAppDrawableRes
 import me.proxer.app.util.extension.toAppString
 import me.proxer.app.util.extension.toEpisodeAppString
 import me.proxer.app.util.extension.toGeneralLanguage
 import me.proxer.library.enums.Category
 import me.proxer.library.enums.MediaLanguage
+import me.proxer.library.util.ProxerUrls
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
 
@@ -80,7 +95,7 @@ fun EpisodeScreen(mediaId: String, mediaName: String? = null) {
 }
 
 @Composable
-private fun EpisodeContent(
+internal fun EpisodeContent(
     data: List<EpisodeRow>?,
     error: ErrorAction?,
     isLoading: Boolean,
@@ -116,9 +131,8 @@ private fun EpisodeContent(
             text = {
                 Column {
                     episodeToBookmark.languageHosterList.forEach { (language, _) ->
-                        Text(
-                            text = language.toAppString(context),
-                            style = MaterialTheme.typography.bodyLarge,
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .clickable {
@@ -130,7 +144,20 @@ private fun EpisodeContent(
                                     bookmarkEpisode = null
                                 }
                                 .padding(vertical = 12.dp),
-                        )
+                        ) {
+                            Image(
+                                painter = painterResource(language.toGeneralLanguage().toAppDrawableRes()),
+                                contentDescription = null,
+                                modifier = Modifier.size(20.dp),
+                            )
+
+                            Spacer(modifier = Modifier.width(12.dp))
+
+                            Text(
+                                text = language.toAppString(context),
+                                style = MaterialTheme.typography.bodyLarge,
+                            )
+                        }
                     }
                 }
             },
@@ -204,41 +231,93 @@ private fun EpisodeItem(episode: EpisodeRow, mediaId: String, mediaName: String?
         }
 
         if (expanded) {
-            episode.languageHosterList.forEach { (language, _) ->
-                Text(
-                    text = language.toAppString(context),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable {
-                            activity ?: return@clickable
-                            when (episode.category) {
-                                Category.ANIME -> AnimeActivity.navigateTo(
-                                    activity,
-                                    mediaId,
-                                    episode.number,
-                                    language.toAnimeLanguage(),
-                                    mediaName,
-                                    episode.episodeAmount,
-                                )
-
-                                Category.MANGA, Category.NOVEL -> MangaActivity.navigateTo(
-                                    activity,
-                                    mediaId,
-                                    episode.number,
-                                    language.toGeneralLanguage(),
-                                    episode.title,
-                                    mediaName,
-                                    episode.episodeAmount,
-                                )
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.padding(top = 8.dp),
+            ) {
+                episode.languageHosterList.forEach { (language, hosterImages) ->
+                    LanguageButton(
+                        language = language,
+                        hosterImages = hosterImages,
+                        onClick = {
+                            if (activity != null) {
+                                navigateToEpisode(activity, episode, language, mediaId, mediaName)
                             }
-                        }
-                        .padding(top = 4.dp, start = 8.dp),
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LanguageButton(language: MediaLanguage, hosterImages: List<String>?, onClick: () -> Unit) {
+    val context = LocalContext.current
+
+    OutlinedButton(
+        onClick = onClick,
+        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp),
+    ) {
+        Image(
+            painter = painterResource(language.toGeneralLanguage().toAppDrawableRes()),
+            contentDescription = null,
+            modifier = Modifier.size(16.dp),
+        )
+
+        Spacer(modifier = Modifier.width(6.dp))
+
+        Text(
+            text = language.toAppString(context),
+            style = MaterialTheme.typography.labelLarge,
+        )
+
+        if (!hosterImages.isNullOrEmpty()) {
+            VerticalDivider(
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .height(16.dp),
+            )
+
+            hosterImages.forEach { hosterImage ->
+                AsyncImage(
+                    model = ProxerUrls.hosterImage(hosterImage).toString(),
+                    contentDescription = null,
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier
+                        .padding(end = 4.dp)
+                        .size(18.dp),
                 )
             }
         }
     }
+}
+
+private fun navigateToEpisode(
+    activity: Activity,
+    episode: EpisodeRow,
+    language: MediaLanguage,
+    mediaId: String,
+    mediaName: String?,
+) = when (episode.category) {
+    Category.ANIME -> AnimeActivity.navigateTo(
+        activity,
+        mediaId,
+        episode.number,
+        language.toAnimeLanguage(),
+        mediaName,
+        episode.episodeAmount,
+    )
+
+    Category.MANGA, Category.NOVEL -> MangaActivity.navigateTo(
+        activity,
+        mediaId,
+        episode.number,
+        language.toGeneralLanguage(),
+        episode.title,
+        mediaName,
+        episode.episodeAmount,
+    )
 }
 
 @Preview(showBackground = true)

--- a/src/main/kotlin/me/proxer/app/media/list/MediaListScreen.kt
+++ b/src/main/kotlin/me/proxer/app/media/list/MediaListScreen.kt
@@ -82,6 +82,7 @@ import me.proxer.app.ui.compose.ProxerTheme
 import me.proxer.app.util.ErrorUtils.ErrorAction
 import me.proxer.app.util.extension.enumSetOf
 import me.proxer.app.util.extension.getQuantityString
+import me.proxer.app.util.extension.toAppDrawableRes
 import me.proxer.app.util.extension.toAppString
 import me.proxer.app.util.extension.toGeneralLanguage
 import me.proxer.library.entity.list.MediaListEntry
@@ -425,14 +426,14 @@ private fun MediaCard(entry: MediaListEntry, category: Category, onClick: () -> 
                 val languages = entry.languages.map { it.toGeneralLanguage() }.distinct()
                 if (languages.contains(Language.GERMAN)) {
                     Image(
-                        painter = painterResource(R.drawable.ic_germany),
+                        painter = painterResource(Language.GERMAN.toAppDrawableRes()),
                         contentDescription = stringResource(R.string.language_german),
                         modifier = Modifier.size(16.dp),
                     )
                 }
                 if (languages.contains(Language.ENGLISH)) {
                     Image(
-                        painter = painterResource(R.drawable.ic_united_states),
+                        painter = painterResource(Language.ENGLISH.toAppDrawableRes()),
                         contentDescription = stringResource(R.string.language_english),
                         modifier = Modifier.size(16.dp),
                     )

--- a/src/main/kotlin/me/proxer/app/util/extension/ProxerLibExtensions.kt
+++ b/src/main/kotlin/me/proxer/app/util/extension/ProxerLibExtensions.kt
@@ -140,9 +140,6 @@ fun Language.toAppDrawableRes() = when (this) {
     Language.OTHER -> R.drawable.ic_united_nations
 }
 
-fun Language.toAppDrawable(context: Context) = AppCompatResources.getDrawable(context, toAppDrawableRes())
-    ?: error("Could not resolve Drawable for language: $this")
-
 fun MediaLanguage.toAppString(context: Context): String = context.getString(
     when (this) {
         MediaLanguage.GERMAN -> R.string.language_german

--- a/src/main/kotlin/me/proxer/app/util/extension/ProxerLibExtensions.kt
+++ b/src/main/kotlin/me/proxer/app/util/extension/ProxerLibExtensions.kt
@@ -4,6 +4,7 @@ package me.proxer.app.util.extension
 
 import android.content.Context
 import android.content.res.Resources
+import androidx.annotation.DrawableRes
 import androidx.appcompat.content.res.AppCompatResources
 import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
@@ -132,14 +133,15 @@ fun AnimeLanguage.toMediaLanguage() = when (this) {
     AnimeLanguage.OTHER -> MediaLanguage.OTHER
 }
 
-fun Language.toAppDrawable(context: Context) = AppCompatResources.getDrawable(
-    context,
-    when (this) {
-        Language.GERMAN -> R.drawable.ic_germany
-        Language.ENGLISH -> R.drawable.ic_united_states
-        Language.OTHER -> R.drawable.ic_united_nations
-    },
-) ?: error("Could not resolve Drawable for language: $this")
+@DrawableRes
+fun Language.toAppDrawableRes() = when (this) {
+    Language.GERMAN -> R.drawable.ic_germany
+    Language.ENGLISH -> R.drawable.ic_united_states
+    Language.OTHER -> R.drawable.ic_united_nations
+}
+
+fun Language.toAppDrawable(context: Context) = AppCompatResources.getDrawable(context, toAppDrawableRes())
+    ?: error("Could not resolve Drawable for language: $this")
 
 fun MediaLanguage.toAppString(context: Context): String = context.getString(
     when (this) {

--- a/src/test/kotlin/me/proxer/app/util/extension/ProxerLibExtensionsTest.kt
+++ b/src/test/kotlin/me/proxer/app/util/extension/ProxerLibExtensionsTest.kt
@@ -1,0 +1,38 @@
+package me.proxer.app.util.extension
+
+import me.proxer.app.R
+import me.proxer.library.enums.Language
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * Unit tests for the resource-id only extensions in ProxerLibExtensions.
+ *
+ * Deliberately free of Koin and [me.proxer.app.util.ErrorUtils]: the latter binds StorageHelper /
+ * PreferenceHelper via `by lazy` once per JVM and would poison sibling tests in the same fork.
+ */
+class ProxerLibExtensionsTest {
+
+    @Test
+    fun `german language maps to germany flag`() {
+        assertEquals(R.drawable.ic_germany, Language.GERMAN.toAppDrawableRes())
+    }
+
+    @Test
+    fun `english language maps to united states flag`() {
+        assertEquals(R.drawable.ic_united_states, Language.ENGLISH.toAppDrawableRes())
+    }
+
+    @Test
+    fun `other language maps to united nations flag`() {
+        assertEquals(R.drawable.ic_united_nations, Language.OTHER.toAppDrawableRes())
+    }
+
+    @Test
+    fun `every language resolves to a valid resource id`() {
+        Language.values().forEach { language ->
+            assertNotEquals("No drawable for $language", 0, language.toAppDrawableRes())
+        }
+    }
+}


### PR DESCRIPTION
Restores the flag icons and hoster icons that were lost in the Compose migration (`bff49889`), replacing the stacked plain-text language labels in the episode/chapter list.

## Before / after

Expanding an episode row rendered each language as a full-width plain-text label, stacked vertically, with no flags. The hoster icons the old UI showed were dropped entirely — `EpisodeRow.languageHosterList` still carried them, but `EpisodeScreen` destructured them away with `{ (language, _) -> }`.

Now each available language is an `OutlinedButton` in a wrapping `FlowRow`: flag at 16dp, label, and for anime a divider plus its hoster icons.

## Notes for review

**It isn't always two languages.** Manga/novel chapters carry `GERMAN`/`ENGLISH`, but anime episodes can carry four variants (`GERMAN_SUB`, `GERMAN_DUB`, `ENGLISH_SUB`, `ENGLISH_DUB`). A flag alone can't distinguish sub from dub, so buttons carry flag *and* label, and the row wraps.

**"No button when unavailable" needed no code** — the list only ever contains languages the API returned.

**Hoster overflow.** `FlowRow` wraps *between* buttons but cannot wrap *within* one, so a long label plus many hosters clipped the trailing icons — a regression against the pre-Compose `FlexboxLayout`, which wrapped. The hoster row carries `weight(1f, fill = false)` so it shrinks rather than clips, plus `horizontalScroll` so the overflow stays reachable.

**Accessibility.** The flag is `contentDescription = null` because the label sits inside the same button. This is deliberately *not* a blanket rule — `MediaListScreen` describes the identical drawable, correctly, because there the flag stands alone. Hoster icons are described by filename minus extension (`crunchyroll.jpg` → `crunchyroll`), since which host serves an episode appears nowhere else as text.

**`Language.toAppDrawable(Context)` was deleted** — zero callers remained once Compose moved to the new `@DrawableRes` variant. It was already dead before this branch.

## Verification

- 369/369 JVM tests
- 9/9 instrumented tests on `Pixel_10_Pro_XL` (API 37)
- `detekt`: 6 findings, all pre-existing in `ChatActivity.kt`, `IndustryActivity.kt`, `ErrorUtils.kt` — files this branch does not touch

Hoster assertions pass `useUnmergedTree = true`; `OutlinedButton` merges its descendants' semantics, so tagged child nodes are otherwise invisible. One test asserts the overflow is scrollable via `performScrollTo()`, so dropping the scroll modifier fails the suite rather than silently regressing to clipping.

## Known follow-ups (not addressed here)

- The flag + spacer + label triplet is duplicated between `LanguageButton` and the bookmark dialog
- `MediaListScreen`'s two `if (languages.contains(...))` blocks remain near-identical
- Tapping a language silently no-ops when the context isn't an `Activity` (pre-existing behaviour)
- `Language.values()` in the new JVM test is soft-deprecated in favour of `.entries`

🤖 Generated with [Claude Code](https://claude.com/claude-code)